### PR TITLE
DR0053A-133 Direct register modify example

### DIFF
--- a/src/controllers/drive_controller.py
+++ b/src/controllers/drive_controller.py
@@ -157,6 +157,16 @@ class DriveController(QObject):
             servo=Drive(drive).name,
         )
 
+    @Slot(float, int)
+    def set_register_max_velocity(self, max_velocity: float, drive: int) -> None:
+        self.mcs.run(
+            self.log_report,
+            "communication.set_register",
+            "CL_VEL_REF_MAX",
+            max_velocity,
+            Drive(drive).name,
+        )
+
     @Slot()
     def get_velocities_r(
         self, timestamps: list[float], data: list[list[float]]

--- a/src/views/ControlsPage.qml
+++ b/src/views/ControlsPage.qml
@@ -39,13 +39,13 @@ RowLayout {
             PlotJS.resetPlot(chartR);
         }
     }
-    Keys.onUpPressed: event => ControlsJS.handleButtonPressed(upButton, 1, 1, event)
+    Keys.onUpPressed: event => ControlsJS.handleButtonPressed(upButton, -1, 1, event)
 
-    Keys.onDownPressed: event => ControlsJS.handleButtonPressed(downButton, -1, -1, event)
+    Keys.onDownPressed: event => ControlsJS.handleButtonPressed(downButton, 1, -1, event)
 
-    Keys.onLeftPressed: event => ControlsJS.handleButtonPressed(leftButton, -1, 1, event)
+    Keys.onLeftPressed: event => ControlsJS.handleButtonPressed(leftButton, 1, 1, event)
 
-    Keys.onRightPressed: event => ControlsJS.handleButtonPressed(rightButton, 1, -1, event)
+    Keys.onRightPressed: event => ControlsJS.handleButtonPressed(rightButton, -1, -1, event)
 
     Keys.onReleased: event => {
         if (event.isAutoRepeat)
@@ -157,7 +157,7 @@ RowLayout {
         GridLayout {
             Layout.fillHeight: true
             Layout.preferredHeight: 1
-            rows: 2
+            rows: 4
             columns: 5
             rowSpacing: 0
             Item {
@@ -170,7 +170,7 @@ RowLayout {
                 id: upButton
                 text: "↑"
                 Layout.alignment: Qt.AlignBottom
-                leftFactor: 1
+                leftFactor: -1
                 rightFactor: 1
             }
             SpacerW {
@@ -179,7 +179,23 @@ RowLayout {
                 RowLayout {
                     Text {
                         color: "#e0e0e0"
-                        text: "Max Velocity L -"
+                        text: "Maximum Velocity L"
+                    }
+                }
+                SpinBox {
+                    from: 0
+                    value: 10
+                    editable: true
+                    onValueModified: () => {
+                        grid.driveController.set_register_max_velocity(value, Enums.Drive.Left);
+                    }
+                }
+            }
+            ColumnLayout {
+                RowLayout {
+                    Text {
+                        color: "#e0e0e0"
+                        text: "Target Velocity L -"
                     }
                     Text {
                         id: velocitySliderLValue
@@ -198,35 +214,50 @@ RowLayout {
                     }
                 }
             }
-            SpacerW {
-            }
 
             StateButton {
                 id: leftButton
                 text: "←"
                 Layout.alignment: Qt.AlignRight | Qt.AlignTop
-                leftFactor: -1
+                leftFactor: 1
                 rightFactor: 1
             }
             StateButton {
                 id: downButton
                 text: "↓"
                 Layout.alignment: Qt.AlignTop
-                leftFactor: -1
+                leftFactor: 1
                 rightFactor: -1
             }
             StateButton {
                 id: rightButton
                 text: "→"
                 Layout.alignment: Qt.AlignLeft | Qt.AlignTop
-                leftFactor: 1
+                leftFactor: -1
                 rightFactor: -1
             }
             ColumnLayout {
                 RowLayout {
                     Text {
                         color: "#e0e0e0"
-                        text: "Max Velocity R -"
+                        text: "Maximum Velocity R"
+                    }
+                }
+                SpinBox {
+                    from: 0
+                    value: 10
+                    editable: true
+                    onValueModified: () => {
+                        grid.driveController.set_register_max_velocity(value, Enums.Drive.Right);
+                    }
+                }
+            }
+
+            ColumnLayout {
+                RowLayout {
+                    Text {
+                        color: "#e0e0e0"
+                        text: "Target Velocity R -"
                     }
                     Text {
                         id: velocitySliderRValue
@@ -244,8 +275,6 @@ RowLayout {
                         velocitySliderRValue.text = velocitySliderR.value.toFixed(2);
                     }
                 }
-            }
-            SpacerW {
             }
 
             Item {


### PR DESCRIPTION
### Docs

https://novantamotion.atlassian.net/browse/DR0053A-133

### Test

There is a set of inputs in the control page that allows us to directly set the register that controls the maximum velocity the drive permits.
If this is set lower than the target velocity, the motor should not move reach a higher velocity than the maximum velocity. Otherwise, the target velocity works as before.