### PR TITLE
DR0053A-130 Improved poller error messaging

### DIFF
--- a/src/services/motion_controller_thread.py
+++ b/src/services/motion_controller_thread.py
@@ -1,13 +1,14 @@
 import time
 from queue import Queue
 
-from ingenialink.exceptions import (
-    ILError,
-)
+import ingenialogger
+from ingenialink.exceptions import ILError, ILIOError
 from ingeniamotion.exceptions import IMException
 from PySide6.QtCore import QThread, Signal
 
 from .types import motion_controller_task, thread_report
+
+logger = ingenialogger.get_logger(__name__)
 
 
 class MotionControllerThread(QThread):
@@ -85,5 +86,9 @@ class MotionControllerThread(QThread):
             if raised_exception is None:
                 self.task_completed.emit(task.callback, report)
             else:
-                self.task_errored.emit(str(report.exceptions))
+                logger.error(report)
+                # We only log ILIOErrors, because they are not important enough to
+                # warrant displaying a error dialog.
+                if not isinstance(raised_exception, ILIOError):
+                    self.task_errored.emit(str(report.exceptions))
             self.queue.task_done()


### PR DESCRIPTION
### Docs 

https://novantamotion.atlassian.net/browse/DR0053A-130

Sometimes a thread errors when trying to read from or write to a register. Previously, this would always cause the error be displayed in an error message that covers the screen and stops the user from interacting with the UI until they close the message box.

This change ensures that less important errors will instead only be logged to the console.

### Test

Connect to the drive as usual and start manipulating the velocities for a while. It is to be expected to occasionally received warnings of this kind in the console:
`2023-12-13 12:22:49,322 | ingenialink.poller | WARNING | Could not read CL_VEL_FBK_VALUE register. This sample is lost for all channels.`
These warnings should not cause an error message box to appear in the gui.