### PR TITLE
DR0053A-147 Emergency button reset interface

### DIFF
--- a/src/controllers/drive_controller.py
+++ b/src/controllers/drive_controller.py
@@ -47,6 +47,9 @@ class DriveController(QObject):
     servo_ids_changed = Signal(QJsonArray, arguments=["servo_ids"])
     """Triggers when the scan returned new values for the servo connections"""
 
+    emergency_stop_triggered = Signal()
+    """Triggers when the emergency stop button was pressed"""
+
     def __init__(self) -> None:
         super().__init__()
         self.mcs = MotionControllerService()
@@ -247,6 +250,9 @@ class DriveController(QObject):
             self.servo_ids_changed.emit(QJsonArray.fromVariantList(servo_ids))
             self.update_connect_button_state()
 
+    def emergency_stop_callback(self, thread_report: thread_report) -> None:
+        self.emergency_stop_triggered.emit()
+
     @Slot()
     def emergency_stop(self) -> None:
-        self.mcs.emergency_stop(self.log_report)
+        self.mcs.emergency_stop(self.emergency_stop_callback)

--- a/src/services/motion_controller_service.py
+++ b/src/services/motion_controller_service.py
@@ -244,6 +244,7 @@ class MotionControllerService(QObject):
             for servo in self.__mc.servos:
                 if self.__mc.is_alive(servo):
                     self.__mc.motion.motor_disable(servo=servo)
+                    self.stop_poller_thread(servo)
 
         return on_thread
 

--- a/src/views/ControlsPage.qml
+++ b/src/views/ControlsPage.qml
@@ -38,6 +38,10 @@ RowLayout {
             PlotJS.resetPlot(chartL);
             PlotJS.resetPlot(chartR);
         }
+        function onEmergency_stop_triggered() {
+            leftCheck.checked = false;
+            rightCheck.checked = false;
+        }
     }
     Keys.onUpPressed: event => ControlsJS.handleButtonPressed(upButton, -1, 1, event)
 


### PR DESCRIPTION
### Docs

https://novantamotion.atlassian.net/browse/DR0053A-147

### Test

Connect to a drive, enable at least one motor. Pressing the emergency button should uncheck the motor enable checkboxes.