### PR TITLE
DR0053A-577 Arrow keys fix

### DIFF
--- a/k2basecamp/views/ControlsPage.qml
+++ b/k2basecamp/views/ControlsPage.qml
@@ -46,13 +46,13 @@ RowLayout {
 
     // Bind velocity controls to the arrow keys on the keyboard.
 
-    Keys.onUpPressed: event => ControlsJS.handleButtonPressed(upButton, -1, 1, event)
+    Keys.onUpPressed: event => ControlsJS.handleButtonPressed(upButton, -1, 1)
 
-    Keys.onDownPressed: event => ControlsJS.handleButtonPressed(downButton, 1, -1, event)
+    Keys.onDownPressed: event => ControlsJS.handleButtonPressed(downButton, 1, -1)
 
-    Keys.onLeftPressed: event => ControlsJS.handleButtonPressed(leftButton, 1, 1, event)
+    Keys.onLeftPressed: event => ControlsJS.handleButtonPressed(leftButton, 1, 1)
 
-    Keys.onRightPressed: event => ControlsJS.handleButtonPressed(rightButton, -1, -1, event)
+    Keys.onRightPressed: event => ControlsJS.handleButtonPressed(rightButton, -1, -1)
 
     Keys.onReleased: event => {
         if (event.isAutoRepeat)
@@ -112,7 +112,7 @@ RowLayout {
             }
         }
         RowLayout {
-            // Graphs to display motor velocities over time. 
+            // Graphs to display motor velocities over time.
             Layout.fillHeight: true
 
             Rectangle {
@@ -164,7 +164,7 @@ RowLayout {
         }
 
         GridLayout {
-            /** Buttons to control velocities. 
+            /** Buttons to control velocities.
              * The arrow key buttons are bound to click events.
              * Sliders to control the target velocities.
              * Inputs to control the maximum velocities.

--- a/k2basecamp/views/components/StateButton.qml
+++ b/k2basecamp/views/components/StateButton.qml
@@ -45,6 +45,6 @@ Button {
             }
         }
     ]
-    onPressed: () => ControlsJS.handleButtonPressed(stateButton, leftFactor, rightFactor)
+    onPressAndHold: () => ControlsJS.handleButtonPressed(stateButton, leftFactor, rightFactor)
     onReleased: () => ControlsJS.handleButtonReleased(stateButton)
 }

--- a/k2basecamp/views/js/controls.js
+++ b/k2basecamp/views/js/controls.js
@@ -6,10 +6,16 @@
  * @param {int} rightFactor 
  * @param {KeyEvent} event 
  */
-function handleButtonPressed(button, leftFactor, rightFactor, event) {
-    // KeyEvents will fire repeatedly if held down (autoRepeat).
-    if (event?.isAutoRepeat || button.state == Enums.ButtonState.Disabled)
+function handleButtonPressed(button, leftFactor, rightFactor) {
+    if (button.state != Enums.ButtonState.Enabled)
         return;
+
+    // Reset all other buttons
+    for (const otherButton of [upButton, downButton, leftButton, rightButton]) {
+        if (button == otherButton || otherButton.state != Enums.ButtonState.Active) continue;
+        otherButton.state = Enums.ButtonState.Enabled;
+    }
+
     button.state = Enums.ButtonState.Active;
     if (leftCheck.checked) {
         grid.connectionController.set_velocity(velocitySliderL.value * leftFactor, Enums.Drive.Left);
@@ -25,7 +31,7 @@ function handleButtonPressed(button, leftFactor, rightFactor, event) {
  * @param {Button} button 
  */
 function handleButtonReleased(button) {
-    if (button.state == Enums.ButtonState.Disabled)
+    if (button.state != Enums.ButtonState.Active)
         return;
     button.state = Enums.ButtonState.Enabled;
     if (leftCheck.checked) {


### PR DESCRIPTION
### Docs

https://novantamotion.atlassian.net/browse/DR0053A-577

The behavior of the interface when pressing multiple arrows simultaneously is being improved with this PR.
The intended result is that only the last pressed key will be active (both visually and its effect).
As before, releasing the active button should cause the motor to stop turning. This will happen even if a previously pressed key is still held down (as it was deactivated when another key was pressed) and is intended behavior.

### Test

Connect to the drive and enable one or both motors. Play with the arrow keys, in particular holding down multiple keys at the same time. Confirm that the behavior is what is described above.