### PR TITLE
DR0053A-575 Reset interface on error

### DIFF
--- a/k2basecamp/controllers/connection_controller.py
+++ b/k2basecamp/controllers/connection_controller.py
@@ -444,6 +444,7 @@ class ConnectionController(QObject):
         Args:
             error_message: the error message.
         """
+        self.emergency_stop()
         self.error_triggered.emit(error_message)
         self.update_connect_button_state()
 

--- a/k2basecamp/views/ControlsPage.qml
+++ b/k2basecamp/views/ControlsPage.qml
@@ -41,6 +41,9 @@ RowLayout {
         function onEmergency_stop_triggered() {
             leftCheck.checked = false;
             rightCheck.checked = false;
+            for (const button of [upButton, downButton, leftButton, rightButton]) {
+                button.state = Enums.ButtonState.Disabled;
+            }
         }
     }
 
@@ -112,7 +115,7 @@ RowLayout {
             }
         }
         RowLayout {
-            // Graphs to display motor velocities over time. 
+            // Graphs to display motor velocities over time.
             Layout.fillHeight: true
 
             Rectangle {
@@ -164,7 +167,7 @@ RowLayout {
         }
 
         GridLayout {
-            /** Buttons to control velocities. 
+            /** Buttons to control velocities.
              * The arrow key buttons are bound to click events.
              * Sliders to control the target velocities.
              * Inputs to control the maximum velocities.


### PR DESCRIPTION
### Docs

https://novantamotion.atlassian.net/browse/DR0053A-575

When loading an erroneous configuration for the drive, the program would not handle the error correctly.
Updating the dependencies (as happened in https://github.com/ingeniamc/k2-base-camp/pull/24) fixes this issue.
This PR adds code that stops the motors and resets the interface when an error occurs.

### Test

1. Connect to the drives using the configuration file attached to the jira issue for at least one of the drives.
2. Enable the motor of both drives. 
3. The badly configured one should prompt an error.
4. Both motors should be disabled and the interface should have been reset.