### PR TITLE
Dr0053 a 586 add two le ds to show drive status

### DIFF
--- a/k2basecamp/views/components/StateImage.qml
+++ b/k2basecamp/views/components/StateImage.qml
@@ -8,7 +8,7 @@ import qmltypes.controllers 1.0
 // no longer used, the warning can be re-enabled.
 // qmllint disable missing-property
 
-// Helper component to abstract some of the state logic 
+// Helper component to abstract some of the state logic
 // for displaying info about the drive.
 
 Image {
@@ -19,13 +19,6 @@ Image {
     state: Enums.SERVO_STATE.DISABLED
     states: [
         State {
-            name: Enums.SERVO_STATE.RDY
-            PropertyChanges {
-                target: stateImage
-                source: "images/circle-available.svg"
-            }
-        },
-        State {
             name: Enums.SERVO_STATE.ENABLED
             PropertyChanges {
                 target: stateImage
@@ -34,6 +27,20 @@ Image {
         },
         State {
             name: Enums.SERVO_STATE.DISABLED
+            PropertyChanges {
+                target: stateImage
+                source: "images/circle-available.svg"
+            }
+        },
+        State {
+            name: Enums.SERVO_STATE.FAULT
+            PropertyChanges {
+                target: stateImage
+                source: "images/circle-fault.svg"
+            }
+        },
+        State {
+            name: Enums.SERVO_STATE.FAULTR
             PropertyChanges {
                 target: stateImage
                 source: "images/circle-fault.svg"


### PR DESCRIPTION
### Docs

The LED colors that represent the motor status behaved differently than they do in MotionLab3. This PR fixes this.

### Test

During all these processes, observe the LEDs that show the motor status and confirm that their color is what you'd expect from the analogous LEDs within MotionLab3.

1. Connect to a drive
2. Enable a motor
3. Disable a motor
4. Re-Connect using a faulty configuration (e.g. over/under-voltage)
5. Enable a motor