### PR TITLE
DR0053A-655 set maximum velocity

### DIFF
--- a/docs/source/pages/examples.rst
+++ b/docs/source/pages/examples.rst
@@ -18,7 +18,7 @@ The objective of this example is changing the value of a register of the drive u
         SpinBox {
             (component properties)
             onValueModified: () => {
-                grid.connectionController.set_register_max_velocity(value, Enums.Drive.Left);
+                grid.connectionController.set_max_velocity(value, Enums.Drive.Left);
             }
         }
 
@@ -60,7 +60,7 @@ The objective of this example is changing the value of a register of the drive u
 #.  Now we can implement the function in the ``ConnectionController``::
 
         @Slot(float, int)
-        def set_register_max_velocity(self, max_velocity: float, drive: int) -> None:
+        def set_max_velocity(self, max_velocity: float, drive: int) -> None:
             self.mcs.run(
                 self.log_report,
                 "communication.set_register",

--- a/k2basecamp/services/motion_controller_service.py
+++ b/k2basecamp/services/motion_controller_service.py
@@ -21,6 +21,8 @@ INTERFACE_CAN = "CAN"
 INTERFACE_ETH = "ETH"
 DEFAULT_DICTIONARY_PATH = "k2basecamp/assets/eve-net-c_can_2.4.1.xdf"
 EXPECTED_NODE_NR_SCAN = 2
+MAX_VELOCITY_REGISTER = "CL_VEL_REF_MAX"
+MAX_PROFILER_VELOCITY_REGISTER = "PROF_MAX_VEL"
 
 
 class MotionControllerService(QObject):
@@ -522,5 +524,36 @@ class MotionControllerService(QObject):
                     ),
                     slave=left_id,
                 )
+
+        return on_thread
+
+    @run_on_thread
+    def set_max_velocity(
+        self,
+        report_callback: Callable[[thread_report], Any],
+        drive: Drive,
+        max_velocity: float,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Callable[..., Any]:
+        """Set the maximum velocity of the given drive. There are two registers that
+        have an effect on this property - we are simply setting them both to the given
+        value to keep things simple in this application.
+
+        Args:
+            report_callback: callback to invoke after
+                completing the operation.
+            drive: the target drive.
+            max_velocity: the new maximum velocity.
+
+        """
+
+        def on_thread(drive: Drive, max_velocity: float) -> Any:
+            self.__mc.communication.set_register(
+                MAX_VELOCITY_REGISTER, max_velocity, drive.name
+            )
+            self.__mc.communication.set_register(
+                MAX_PROFILER_VELOCITY_REGISTER, max_velocity, drive.name
+            )
 
         return on_thread

--- a/k2basecamp/views/ControlsPage.qml
+++ b/k2basecamp/views/ControlsPage.qml
@@ -59,10 +59,12 @@ RowLayout {
             switch (drive) {
                 case Enums.Drive.Left:
                     maxVelocityLeft.value = newValue;
+                    velocitySliderLValue.text = newValue.toFixed(2);
                     velocitySliderL.to = newValue;
                     break;
                 case Enums.Drive.Right:
                     maxVelocityRight.value = newValue;
+                    velocitySliderRValue.text = newValue.toFixed(2);
                     velocitySliderR.to = newValue;
                     break;
                 default:
@@ -239,12 +241,15 @@ RowLayout {
                 }
                 SpinBox {
                     id: maxVelocityLeft
-                    from: 0
+                    from: 1
                     to: 1000
                     editable: true
                     onValueModified: () => {
+                        if (velocitySliderL.value > value) {
+                            velocitySliderLValue.text = value.toFixed(2);
+                        }
                         velocitySliderL.to = value;
-                        grid.connectionController.set_register_max_velocity(value, Enums.Drive.Left);
+                        grid.connectionController.set_max_velocity(value, Enums.Drive.Left);
                     }
                 }
             }
@@ -262,7 +267,7 @@ RowLayout {
                 }
                 Slider {
                     id: velocitySliderL
-                    from: 1
+                    from: 0
                     to: 10
                     value: 5
                     onMoved: () => {
@@ -302,12 +307,15 @@ RowLayout {
                 }
                 SpinBox {
                     id: maxVelocityRight
-                    from: 0
+                    from: 1
                     to: 1000
                     editable: true
                     onValueModified: () => {
+                        if (velocitySliderR.value > value) {
+                            velocitySliderRValue.text = value.toFixed(2);
+                        }
                         velocitySliderR.to = value;
-                        grid.connectionController.set_register_max_velocity(value, Enums.Drive.Right);
+                        grid.connectionController.set_max_velocity(value, Enums.Drive.Right);
                     }
                 }
             }
@@ -326,7 +334,7 @@ RowLayout {
                 }
                 Slider {
                     id: velocitySliderR
-                    from: 1
+                    from: 0
                     to: 10
                     value: 5
                     onMoved: () => {


### PR DESCRIPTION
### Docs

[issue](https://novantamotion.atlassian.net/browse/DR0053A-655)

Setting the maximum velocity now simultaneously updates both registers that influence the maximum velocity in the drive. This should make it more intuitive to use the application, as the maximum velocity setting now directly correlates with the maximum velocity the motor will move at (rather than having an "invisible" cap).

Also updated the slider behavior when reducing the maximum below the currently set target.

### Test

1. Connect a drive and set a maximum velocity.
2. Enable and move the motor. It should be possible to achieve the velocity that was set.
3. Reduce the maximum below the currently set target
![image](https://github.com/ingeniamc/k2-base-camp/assets/64021569/150e9d15-89d5-4158-a276-e05074c3b770)
4. The currently set target should automatically update accordingly
![image](https://github.com/ingeniamc/k2-base-camp/assets/64021569/b7eea5e2-b783-4859-a8bb-6bf8cdceda10)
