### PR TITLE
DR0053A-719 Show error message when drive goes to fault

### DIFF
--- a/k2basecamp/controllers/connection_controller.py
+++ b/k2basecamp/controllers/connection_controller.py
@@ -536,7 +536,6 @@ class ConnectionController(QObject):
         if state == SERVO_STATE.FAULT:
             self.mcs.get_last_error(self.show_last_error, drive)
 
-
     @Slot(Drive, NET_DEV_EVT)
     def update_net_state(self, drive: Drive, state: NET_DEV_EVT) -> None:
         """Send a signal to the GUI to update the interface when the network state

--- a/k2basecamp/services/motion_controller_service.py
+++ b/k2basecamp/services/motion_controller_service.py
@@ -557,3 +557,29 @@ class MotionControllerService(QObject):
             )
 
         return on_thread
+
+    @run_on_thread
+    def get_last_error(
+        self,
+        report_callback: Callable[[thread_report], Any],
+        drive: Drive,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Callable[..., Any]:
+        """Get the last error of a given drive.
+
+        Args:
+            report_callback: callback to invoke after
+                completing the operation.
+            drive: the target drive.
+
+        """
+
+        def on_thread(drive: Drive) -> Any:
+            error_code, *_ = self.__mc.errors.get_last_buffer_error(
+                servo=drive.name
+            )
+            *_, error_msg = self.__mc.errors.get_error_data(error_code, servo=drive.name)
+            return error_msg
+
+        return on_thread

--- a/k2basecamp/services/motion_controller_service.py
+++ b/k2basecamp/services/motion_controller_service.py
@@ -576,10 +576,10 @@ class MotionControllerService(QObject):
         """
 
         def on_thread(drive: Drive) -> Any:
-            error_code, *_ = self.__mc.errors.get_last_buffer_error(
-                servo=drive.name
+            error_code, *_ = self.__mc.errors.get_last_buffer_error(servo=drive.name)
+            *_, error_msg = self.__mc.errors.get_error_data(
+                error_code, servo=drive.name
             )
-            *_, error_msg = self.__mc.errors.get_error_data(error_code, servo=drive.name)
             return error_msg
 
         return on_thread


### PR DESCRIPTION
Test:

- Connect to a K2.
- Enable a motor.
- Force an error.
- Check that the drive goes to fault.
- Check that the error is reported.