### PR TITLE
Dr0053A-740 LEDs dont reflect the drive status correctly

### DIFF
--- a/k2basecamp/controllers/connection_controller.py
+++ b/k2basecamp/controllers/connection_controller.py
@@ -510,7 +510,6 @@ class ConnectionController(QObject):
         Args:
             error_message: the error message.
         """
-        self.emergency_stop()
         self.error_triggered.emit(error_message)
         self.update_connect_button_state()
 

--- a/k2basecamp/views/js/controls.js
+++ b/k2basecamp/views/js/controls.js
@@ -78,7 +78,4 @@ function resetControls(drivesConnected = true) {
     for (const button of [upButton, downButton, leftButton, rightButton]) {
         button.state = Enums.ButtonState.Disabled
     }
-    for (const stateLED of [leftState, rightState]) {
-        stateLED.state = Enums.SERVO_STATE.DISABLED
-    }
 }


### PR DESCRIPTION
- Connect to K2.
- Check that both LEDs are yellow.
- Force an Input stage error.
- Try to enable the left motor.
- Check that the left motor is at fault.
- Check that the left LED is red and the right LED is yellow.
- Try to enable the right motor.
- Check that the right motor is at fault.
- Check that both LEDs are red.
