### PR TITLE
DR0053A-739 Reset the plots upon a disconnection

### DIFF
--- a/k2basecamp/controllers/connection_controller.py
+++ b/k2basecamp/controllers/connection_controller.py
@@ -548,6 +548,7 @@ class ConnectionController(QObject):
         """
         if state == NET_DEV_EVT.REMOVED:
             self.mcs.stop_poller_thread(drive.name)
+            self.drive_disconnected_triggered.emit()
             self.error_triggered.emit("Network connection lost.")
         self.net_state_changed.emit(state.value)
 


### PR DESCRIPTION
**Test:**

1. Connect to a K2.
2. Enable the motor.
3. Move the motor.
4. Disconnect the cable.
5. Connect the cable.
6. Enable the motor.
7. Move the motor.
8. Check that the data displayed in the plot is correct.